### PR TITLE
Fixes missing tooltip for non coloured boxes.

### DIFF
--- a/src/main/java/net/kyrptonaught/upgradedshulker/compat/shulkertooltip/ShulkerTooltip.java
+++ b/src/main/java/net/kyrptonaught/upgradedshulker/compat/shulkertooltip/ShulkerTooltip.java
@@ -22,8 +22,9 @@ public class ShulkerTooltip implements ShulkerBoxTooltipApi {
         UPGRADED_SHULKER_BOX_ITEMS_MAP = new HashMap<>();
         for (ShulkerUpgrades.MATERIAL material : ShulkerUpgrades.MATERIAL.values()) {
             List<Item> itemsList = new ArrayList<>();
+            itemsList.add(ShulkersRegistry.upgradedShulkerBlocks.get(material).asItem());
             ShulkersRegistry.SHULKER_BLOCKS.get(material).values().forEach(b -> itemsList.add(b.asItem()));
-
+            
             UPGRADED_SHULKER_BOX_ITEMS_MAP.put(material, itemsList.toArray(new Item[0]));
         }
     }
@@ -32,7 +33,7 @@ public class ShulkerTooltip implements ShulkerBoxTooltipApi {
     public void registerProviders(PreviewProviderRegistry registry) {
         for (ShulkerUpgrades.MATERIAL material : ShulkerUpgrades.MATERIAL.values()) {
             Item[] items = UPGRADED_SHULKER_BOX_ITEMS_MAP.get(material);
-            registry.register(new Identifier(UpgradedShulkerMod.MOD_ID, material.name + "_upgraded_shulker_boc"), new UpgradedShulkersPreviewProvider(material), items);
+            registry.register(new Identifier(UpgradedShulkerMod.MOD_ID, material.name + "_upgraded_shulker_box"), new UpgradedShulkersPreviewProvider(material), items);
         }
     }
 }


### PR DESCRIPTION
Looks like I missed that non coloured shulker boxes are handled differently in ShulkersRegistry.
As a result non coloured boxes have no tooltips.

I'm sorry I only used coloured in my test world.